### PR TITLE
Couple of Bug Fixes

### DIFF
--- a/Source/Service/Messaging/ArchiveRequestSender.cs
+++ b/Source/Service/Messaging/ArchiveRequestSender.cs
@@ -1,4 +1,5 @@
-﻿using RabbitMQ.Client;
+﻿using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
 using System;
 using System.Collections.Generic;
 
@@ -9,14 +10,18 @@ namespace Service.Messaging
         private const string Exchange = "adaptation-exchange";
         private const string RoutingKey = "archive-adaptation-request";
 
+        private readonly ILogger<ArchiveRequestSender> _logger;
+
         private readonly IConnectionFactory _connectionFactory;
         private IConnection _connection;
         private IModel _channel;
 
         private bool disposedValue;
 
-        public ArchiveRequestSender(IFileProcessorConfig fileProcessorConfig)
+        public ArchiveRequestSender(IFileProcessorConfig fileProcessorConfig, ILogger<ArchiveRequestSender> logger)
         {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
             if (fileProcessorConfig == null) throw new ArgumentNullException(nameof(fileProcessorConfig));
             _connectionFactory = new ConnectionFactory()
             {
@@ -66,7 +71,7 @@ namespace Service.Messaging
             replyProps.Headers = headers;
             _channel.BasicPublish(Exchange, RoutingKey, basicProperties: replyProps);
 
-            Console.WriteLine($"Sent Archive Request, FileId: {fileId}, SourceFileLocation: {sourceLocation}, " +
+            _logger.LogInformation($"Sent Archive Request, FileId: {fileId}, SourceFileLocation: {sourceLocation}, " +
                 $"RebuiltFileLocation: {rebuiltLocation}, ReplyTo: {replyTo}");
         }
     }

--- a/Source/Service/Messaging/OutcomeSender.cs
+++ b/Source/Service/Messaging/OutcomeSender.cs
@@ -1,4 +1,5 @@
-﻿using RabbitMQ.Client;
+﻿using Microsoft.Extensions.Logging;
+using RabbitMQ.Client;
 using System;
 using System.Collections.Generic;
 
@@ -8,11 +9,15 @@ namespace Service.Messaging
     {
         private bool disposedValue;
 
+        private readonly ILogger<OutcomeSender> _logger;
+
         private readonly IModel _channel;
         private readonly IConnection _connection;
 
-        public OutcomeSender(IFileProcessorConfig fileProcessorConfig)
+        public OutcomeSender(IFileProcessorConfig fileProcessorConfig, ILogger<OutcomeSender> logger)
         {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
             if (fileProcessorConfig == null) throw new ArgumentNullException(nameof(fileProcessorConfig));
             var connectionFactory = new ConnectionFactory() { 
                 HostName = fileProcessorConfig.AdaptationRequestQueueHostname,
@@ -23,7 +28,7 @@ namespace Service.Messaging
             _connection = connectionFactory.CreateConnection();
             _channel = _connection.CreateModel();
 
-            Console.WriteLine($"OutcomeSender Connection established to {fileProcessorConfig.AdaptationRequestQueueHostname}");
+            _logger.LogInformation($"OutcomeSender Connection established to {fileProcessorConfig.AdaptationRequestQueueHostname}");
         }
 
         protected virtual void Dispose(bool disposing)
@@ -59,7 +64,7 @@ namespace Service.Messaging
             replyProps.Headers = headers;
             _channel.BasicPublish("", replyTo, basicProperties: replyProps);
 
-            Console.WriteLine($"Sent Message, ReplyTo: { replyTo}, FileId: {fileId}, Outcome: {status}");
+            _logger.LogInformation($"Sent Message, ReplyTo: { replyTo}, FileId: {fileId}, Outcome: {status}");
         }
     }
 }

--- a/Source/Service/Service.csproj
+++ b/Source/Service/Service.csproj
@@ -12,11 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />

--- a/Source/Service/Startup.cs
+++ b/Source/Service/Startup.cs
@@ -8,6 +8,7 @@ using Glasswall.Core.Engine.Common.PolicyConfig;
 using Glasswall.Core.Engine.FileProcessing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Service.ErrorReport;
 using Service.Messaging;
 
@@ -42,6 +43,7 @@ namespace Service
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddLogging(configure => configure.AddConsole());
             services.AddTransient<IGlasswallVersionService, GlasswallVersionService>();
             services.AddTransient<IFileTypeDetector, FileTypeDetector>();
             services.AddTransient<IFileProtector, FileProtector>();

--- a/Tests/Service.Tests/TransactionEventProcessorTests.cs
+++ b/Tests/Service.Tests/TransactionEventProcessorTests.cs
@@ -60,10 +60,44 @@ namespace Service.Tests
             }
 
             [Test]
-            public void Correct_Outcome_Is_Sent_When_The_File_Does_Not_Exist()
+            public void Failed_Outcome_Is_Sent_When_The_File_Does_Not_Exist()
             {
                 // Arrange
                 _mockFileManager.Setup(s => s.FileExists(It.IsAny<string>())).Returns(false);
+
+                // Act
+                _transactionEventProcessor.Process();
+
+                // Assert
+                _mockOutcomeSender.Verify(s => s.Send(
+                    It.Is<string>(status => status == FileOutcome.Failed),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()));
+            }
+
+            [Test]
+            public void Failed_Outcome_Is_Sent_When_An_Exception_Is_Thrown()
+            {
+                // Arrange
+                _mockFileManager.Setup(s => s.FileExists(It.IsAny<string>())).Returns(true);
+                _mockGlasswallFileProcessor.Setup(s => s.GetFileType(It.IsAny<byte[]>())).Throws(new Exception());
+
+                // Act
+                _transactionEventProcessor.Process();
+
+                // Assert
+                _mockOutcomeSender.Verify(s => s.Send(
+                    It.Is<string>(status => status == FileOutcome.Failed),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()));
+            }
+
+            [Test]
+            public void Failed_Outcome_Is_Sent_When_Timeout_Is_Exceeded()
+            {
+                // Arrange
+                _mockFileManager.Setup(s => s.FileExists(It.IsAny<string>())).Returns(true);
+                _mockGlasswallFileProcessor.Setup(s => s.GetFileType(It.IsAny<byte[]>())).Throws(new Exception());
 
                 // Act
                 _transactionEventProcessor.Process();


### PR DESCRIPTION
Fix for checking if the file exists.
Send outcome message if processing fails, so that icap-service does not have to wait for the timeout to be hit.
Generate error report if exception is thrown or timeout is hit. 

closes #26 
closes #25 

Not sure if we should be failing the pod on file not existing, not sure that is standard practice for Kubernetes. Any thoughts on the current approach, let me know.