### PR TITLE
Send back Replacement mimetype when received

### DIFF
--- a/Source/Service/Messaging/IOutcomeSender.cs
+++ b/Source/Service/Messaging/IOutcomeSender.cs
@@ -4,6 +4,6 @@ namespace Service.Messaging
 {
     public interface IOutcomeSender
     {
-        void Send(string status, string fileId, string replyTo, Dictionary<string, string> optionalHeaders = null);
+        void Send(string status, string fileId, string replyTo, IDictionary<string, string> optionalHeaders = null);
     }
 }

--- a/Source/Service/Messaging/IOutcomeSender.cs
+++ b/Source/Service/Messaging/IOutcomeSender.cs
@@ -1,7 +1,9 @@
-﻿namespace Service.Messaging
+﻿using System.Collections.Generic;
+
+namespace Service.Messaging
 {
     public interface IOutcomeSender
     {
-        void Send(string status, string fileId, string replyTo);
+        void Send(string status, string fileId, string replyTo, Dictionary<string, string> optionalHeaders = null);
     }
 }

--- a/Source/Service/Messaging/OutcomeSender.cs
+++ b/Source/Service/Messaging/OutcomeSender.cs
@@ -53,13 +53,21 @@ namespace Service.Messaging
             GC.SuppressFinalize(this);
         }
 
-        public void Send(string status, string fileId, string replyTo)
+        public void Send(string status, string fileId, string replyTo, Dictionary<string, string> optionalHeaders = null)
         {
             var headers = new Dictionary<string, object>()
                 {
                     { "file-id", fileId },
                     { "file-outcome", status },
                 };
+
+            if (optionalHeaders != null)
+            {
+                foreach (var header in optionalHeaders)
+                {
+                    headers.Add(header.Key, header.Value);
+                }
+            }
 
             var replyProps = _channel.CreateBasicProperties();
             replyProps.Headers = headers;

--- a/Source/Service/Messaging/OutcomeSender.cs
+++ b/Source/Service/Messaging/OutcomeSender.cs
@@ -53,7 +53,7 @@ namespace Service.Messaging
             GC.SuppressFinalize(this);
         }
 
-        public void Send(string status, string fileId, string replyTo, Dictionary<string, string> optionalHeaders = null)
+        public void Send(string status, string fileId, string replyTo, IDictionary<string, string> optionalHeaders = null)
         {
             var headers = new Dictionary<string, object>()
                 {

--- a/Source/Service/NCFS/INcfsProcessor.cs
+++ b/Source/Service/NCFS/INcfsProcessor.cs
@@ -6,7 +6,7 @@ namespace Service.NCFS
 {
     public interface INcfsProcessor
     {
-        Task<string> GetUnmanagedActionAsync(DateTime timestamp, string base64File, FileType fileType);
-        Task<string> GetBlockedActionAsync(DateTime timestamp, string base64File, FileType fileType);
+        Task<NcfsOutcome> GetUnmanagedActionAsync(DateTime timestamp, string base64File, FileType fileType);
+        Task<NcfsOutcome> GetBlockedActionAsync(DateTime timestamp, string base64File, FileType fileType);
     }
 }

--- a/Source/Service/NCFS/NcfsClient.cs
+++ b/Source/Service/NCFS/NcfsClient.cs
@@ -40,7 +40,8 @@ namespace Service.NCFS
                 return new NcfsOutcome
                 {
                     NcfsDecision = Enum.Parse<NcfsDecision>(response.Headers.FirstOrDefault("ncfs-decision")),
-                    Base64Replacement = responseJson?.base64Replacement ?? string.Empty
+                    Base64Replacement = responseJson?.base64Replacement ?? string.Empty,
+                    ReplacementMimeType = response.Headers.FirstOrDefault("ncfs-replacement-mimetype")
                 };
             }
             catch (FlurlHttpException ex)

--- a/Source/Service/NCFS/NcfsOutcome.cs
+++ b/Source/Service/NCFS/NcfsOutcome.cs
@@ -5,6 +5,8 @@ namespace Service.NCFS
     public class NcfsOutcome
     {
         public NcfsDecision NcfsDecision { get; set; }
+        public string FileOutcome { get; set; }
         public string Base64Replacement { get; set; }
+        public string ReplacementMimeType { get; set; }
     }
 }

--- a/Source/Service/NCFS/NcfsProcessor.cs
+++ b/Source/Service/NCFS/NcfsProcessor.cs
@@ -53,14 +53,12 @@ namespace Service.NCFS
             }
             else
             {
-                var ncfsOutcome = new NcfsOutcome
+                return new NcfsOutcome
                 {
                     FileOutcome = _config.UnprocessableFileTypeAction == NcfsOption.Block
                     ? FileOutcome.Failed
                     : FileOutcome.Unmodified
                 };
-
-                return ncfsOutcome;
             }
         }
 
@@ -80,14 +78,12 @@ namespace Service.NCFS
             }
             else
             {
-                var ncfsOutcome = new NcfsOutcome
+                return new NcfsOutcome
                 {
                     FileOutcome = _config.GlasswallBlockedFilesAction == NcfsOption.Block
                     ? FileOutcome.Failed
                     : FileOutcome.Unmodified
                 };
-
-                return ncfsOutcome;
             }
         }
 

--- a/Source/Service/Outcome.cs
+++ b/Source/Service/Outcome.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Service
+{
+    public class Outcome
+    {
+        public string Status { get; set; }
+        public Dictionary<string,string> OptionalHeaders { get; set; }
+
+        public Outcome()
+        {
+            OptionalHeaders = new Dictionary<string, string>();
+        }
+    }
+}

--- a/Tests/Service.Tests/NCFS/NcfsClientTests.cs
+++ b/Tests/Service.Tests/NCFS/NcfsClientTests.cs
@@ -43,7 +43,7 @@ namespace Service.Tests.NCFS
             [TestCase(NcfsDecision.Block)]
             [TestCase(NcfsDecision.Relay)]
             [TestCase(NcfsDecision.Replace)]
-            public async Task Successful_Call_To_The_API_Returns_Correct_Outcome(NcfsDecision expectedDecision)
+            public async Task Successful_Call_To_The_API_Returns_Correct_Decision(NcfsDecision expectedDecision)
             {
                 // Arrange
                 var expectedBase64 = "Expected Replacement";
@@ -55,7 +55,39 @@ namespace Service.Tests.NCFS
 
                 // Assert
                 Assert.That(result.NcfsDecision, Is.EqualTo(expectedDecision));
+            }
+
+            [Test]
+            public async Task Successful_Call_To_The_API_Returns_Base64_Replacement()
+            {
+                // Arrange
+                var expectedDecision = NcfsDecision.Replace;
+                var expectedBase64 = "Expected Replacement";
+
+                _httpTest.RespondWithJson(new { base64Replacement = expectedBase64 }, headers: new Dictionary<string, string>() { { "ncfs-decision", expectedDecision.ToString() } });
+
+                // Act
+                var result = await _client.GetOutcome("base64", FileType.Doc);
+
+                // Assert
                 Assert.That(result.Base64Replacement, Is.EqualTo(expectedBase64));
+            }
+
+            [Test]
+            public async Task Successful_Call_To_The_API_Returns_Replacement_MimeType()
+            {
+                // Arrange
+                var expectedDecision = NcfsDecision.Replace;
+                var expectedBase64 = "Expected Replacement";
+                var expectedMimeType = "text/json";
+
+                _httpTest.RespondWithJson(new { base64Replacement = expectedBase64 }, headers: new Dictionary<string, string>() { { "ncfs-decision", expectedDecision.ToString() }, { "ncfs-replacement-mimetype", expectedMimeType } });
+
+                // Act
+                var result = await _client.GetOutcome("base64", FileType.Doc);
+
+                // Assert
+                Assert.That(result.ReplacementMimeType, Is.EqualTo(expectedMimeType));
             }
 
             [Test]

--- a/Tests/Service.Tests/NCFS/NcfsProcessorTests.cs
+++ b/Tests/Service.Tests/NCFS/NcfsProcessorTests.cs
@@ -98,7 +98,7 @@ namespace Service.Tests.NCFS
                 var result = await _ncfsProcessor.GetUnmanagedActionAsync(timestamp, base64File, fileType);
 
                 // Assert
-                Assert.That(result, Is.EqualTo(expectedOutcome));
+                Assert.That(result.FileOutcome, Is.EqualTo(expectedOutcome));
             }
 
             [TestCase(NcfsDecision.Relay, FileOutcome.Unmodified)]
@@ -118,7 +118,7 @@ namespace Service.Tests.NCFS
                 var result = await _ncfsProcessor.GetUnmanagedActionAsync(timestamp, base64File, fileType);
 
                 // Assert
-                Assert.That(result, Is.EqualTo(expectedOutcome));
+                Assert.That(result.FileOutcome, Is.EqualTo(expectedOutcome));
             }
 
             [Test]
@@ -128,7 +128,6 @@ namespace Service.Tests.NCFS
                 var timestamp = DateTime.UtcNow;
                 var base64File = "Base64FileString";
                 var fileType = FileType.Doc;
-                var expectedOutcome = FileOutcome.Replace;
                 var expectedReplacement = "I AM THE REPLACEMENT BASE64";
                 var outputPath = "OUTPUT PATH";
 
@@ -142,7 +141,6 @@ namespace Service.Tests.NCFS
                 var result = await _ncfsProcessor.GetUnmanagedActionAsync(timestamp, base64File, fileType);
 
                 // Assert
-                Assert.That(result, Is.EqualTo(expectedOutcome));
                 _mockFileManager.Verify(s => s.WriteFile(
                     It.Is<string>(o => o == outputPath),
                     It.Is<byte[]>(file => file.Where((b, i) => b == replacementBytes[i]).Count() == replacementBytes.Length)), Times.Once);
@@ -229,7 +227,7 @@ namespace Service.Tests.NCFS
                 var result = await _ncfsProcessor.GetBlockedActionAsync(timestamp, base64File, fileType);
 
                 // Assert
-                Assert.That(result, Is.EqualTo(expectedOutcome));
+                Assert.That(result.FileOutcome, Is.EqualTo(expectedOutcome));
             }
 
             [TestCase(NcfsDecision.Relay, FileOutcome.Unmodified)]
@@ -249,7 +247,7 @@ namespace Service.Tests.NCFS
                 var result = await _ncfsProcessor.GetBlockedActionAsync(timestamp, base64File, fileType);
 
                 // Assert
-                Assert.That(result, Is.EqualTo(expectedOutcome));
+                Assert.That(result.FileOutcome, Is.EqualTo(expectedOutcome));
             }
 
             [Test]
@@ -259,7 +257,6 @@ namespace Service.Tests.NCFS
                 var timestamp = DateTime.UtcNow;
                 var base64File = "Base64FileString";
                 var fileType = FileType.Doc;
-                var expectedOutcome = FileOutcome.Replace;
                 var expectedReplacement = "I AM THE REPLACEMENT BASE64";
                 var outputPath = "OUTPUT PATH";
 
@@ -273,7 +270,6 @@ namespace Service.Tests.NCFS
                 var result = await _ncfsProcessor.GetBlockedActionAsync(timestamp, base64File, fileType);
 
                 // Assert
-                Assert.That(result, Is.EqualTo(expectedOutcome));
                 _mockFileManager.Verify(s => s.WriteFile(
                     It.Is<string>(o => o == outputPath),
                     It.Is<byte[]>(file => file.Where((b, i) => b == replacementBytes[i]).Count() == replacementBytes.Length)), Times.Once);

--- a/Tests/Service.Tests/TransactionEventProcessorTests.cs
+++ b/Tests/Service.Tests/TransactionEventProcessorTests.cs
@@ -14,6 +14,7 @@ using Service.Storage;
 using Service.StoreMessages.Enums;
 using Service.TransactionEvent;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -78,7 +79,8 @@ namespace Service.Tests
                 _mockOutcomeSender.Verify(s => s.Send(
                     It.Is<string>(status => status == FileOutcome.Failed),
                     It.IsAny<string>(),
-                    It.IsAny<string>()));
+                    It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, string>>()));
             }
 
             [Test]
@@ -95,7 +97,8 @@ namespace Service.Tests
                 _mockOutcomeSender.Verify(s => s.Send(
                     It.Is<string>(status => status == FileOutcome.Failed),
                     It.IsAny<string>(),
-                    It.IsAny<string>()));
+                    It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, string>>()));
             }
 
             [Test]
@@ -112,7 +115,8 @@ namespace Service.Tests
                 _mockOutcomeSender.Verify(s => s.Send(
                     It.Is<string>(status => status == FileOutcome.Failed),
                     It.IsAny<string>(),
-                    It.IsAny<string>()));
+                    It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, string>>()));
             }
 
             [Test]
@@ -133,7 +137,8 @@ namespace Service.Tests
                 _mockOutcomeSender.Verify(s => s.Send(
                     It.Is<string>(status => status == expected),
                     It.IsAny<string>(),
-                    It.IsAny<string>()));
+                    It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, string>>()));
             }
 
             [TestCase(FileType.Zip)]


### PR DESCRIPTION
Add optional header to the adaptation outcome message for the replacement mimetype returned by the ncfs api.